### PR TITLE
Patch associate test

### DIFF
--- a/associateLambda/index.ts
+++ b/associateLambda/index.ts
@@ -2,8 +2,8 @@
 
 interface AssocEvent {
   path: string;
+  method: string;
   body?: string;
-  method?: string;
 }
 
 //figures out what http method has been called: GET, PUT, PATCH

--- a/associateLambda/test/index.test.ts
+++ b/associateLambda/test/index.test.ts
@@ -1,10 +1,12 @@
 //Tests for associate lambda handler and helpers
 
-import { handler, getAssociate, putAssociate, patchAssociate, qcFeedback } from '../index';
+const { handler, getAssociate, putAssociate, patchAssociate, qcFeedback } = require('../index');
+const { Client } = require('pg');
+
 let testEvent = {
     path: 'path',
-    body?: {"1":1},
-    method?: 'method'
+    body: {"1":1},
+    method: 'method'
 }
 
 describe('tests for handler', () => {
@@ -57,7 +59,7 @@ describe('tests for putAssociate', () => {
 });
 
 describe('tests for patchAssociate', () => {
-    const original: qcFeedback = {
+    const original = {
         batchId: 'YYMM-mmmDD-Stuff',
         weekId: 1,
         associateId: 'example@example.net',
@@ -70,7 +72,7 @@ describe('tests for patchAssociate', () => {
     const mockEnd = jest.fn();
     jest.mock('pg', ()=>{
         return {
-            Client: ()=>({connect: mockConnect, query: mockQuery, end: mockEnd})
+            Client: jest.fn(()=>({connect: mockConnect, query: mockQuery, end: mockEnd}))
         }
     });
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    presets: [
+      ['@babel/preset-env', {targets: {node: 'current'}}],
+      '@babel/preset-typescript'
+    ]
+  };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,6 +1656,16 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/pg": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.14.9.tgz",
+      "integrity": "sha512-ThTOEwOvYM++zRSGiajRqKyTQboCEJE2VI+30d93WX94sQ7CnrcJ7CICT9oC+QD8Co9JTYJkKEfEXSb5DjUOFA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "@types/prettier": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-typescript": "^7.12.13",
     "@types/cors": "^2.8.9",
     "@types/jest": "^26.0.20",
+    "@types/pg": "^7.14.9",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
     "typescript": "^4.1.5"


### PR DESCRIPTION
Actually tried to run the test and realized a) we need a babel.config file, b) I mocked Client slightly wrong and that makes me sad, c) @types/pg makes red squiggles go away and that makes me happy.

Also method shouldn't be optional in the AssociateEvent interface, my bad